### PR TITLE
fail if there is an error running cf-list-hosts.sh

### DIFF
--- a/ansible/dynamic_inventory.yml
+++ b/ansible/dynamic_inventory.yml
@@ -4,6 +4,7 @@
 - name: Get Hosts from aws
   shell: ../ansible/scripts/cf-list-hosts.sh all {{config}}-{{guid}} {{aws_region}}
   register: group_hostnames
+  failed_when: group_hostnames.stderr
   tags: [ dynamic_inventory, get_hosts ]
 
 - name: Add Hosts


### PR DESCRIPTION
Even though the script fails, ansible still registers the task as changed, which may impact downstream tasks.  Need to force a fail if the script fails for any reason. 